### PR TITLE
docs: update boost guidelines to note VerifiesDoubles import requirement

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -60,7 +60,8 @@ $repository->allows('save')->with(Argument::satisfies(fn (Book $book) => $book->
 
 - Use `received('method')` for post-hoc assertions. It means at least once by default and supports `with()`, `times()`, and `never()`. It self-verifies once the assertion falls out of scope, so no extra call is needed to trigger it.
 - Use `unused()` to assert that no method was called on the double.
-- `expects()`/`allows()` expectations need an explicit check: PHPUnit and Pest projects can use `JMac\Testing\Integrations\PHPUnit\VerifiesDoubles`, which verifies all expectations after each test.
+- Every PHPUnit test file that uses `Double` must import `JMac\Testing\Integrations\PHPUnit\VerifiesDoubles` and add `use VerifiesDoubles;` to its test class. The trait verifies all expectations after each test.
+- Pest projects must register `VerifiesDoubles` in `tests/Pest.php` for every directory containing tests that use `Double`.
 - Without the trait, call `$double->verify()` before the test ends to check `expects()`/`allows()` expectations.
 
 @verbatim


### PR DESCRIPTION
I made it more clear to agents that when they are creating greenfield test classes, they *must* import the `VerifiesDoubles` trait, rather than the previous grammar which possibly made the import seem optional.  I left the `$double->verify()` note in, as it's possible that for whatever reason, a developer may already have an existing test class while not wanting to import the trait, and so this guideline should generally respect that choice.

Inspiration: [JMac stream](https://www.youtube.com/watch?v=WkHX9BsVaRE)