### PR TITLE
Improve failure message for similar expectations

### DIFF
--- a/docs/07-failure-messages.md
+++ b/docs/07-failure-messages.md
@@ -19,31 +19,47 @@ $repository->verify();
 ```
 Double `foo` expected `find('baz')` to be called exactly 1 time, but it was never called.
 
-The following calls to `find` were made during this test: `find('Baz')`
-
-Argument 1: expected 'baz', got 'Baz'
+The following similar call was made to `find`:
+  value:
+    - 'baz'
+    + 'Baz'
 ```
 
-That second line comes straight from the call log: `find()` really was called, just not with anything that matched. The third line only appears when there's exactly one such call — with two or more, there's no fact-based way to say which one this expectation was "supposed" to match, so the message correlates without guessing.
+That block only appears when there's exactly one call to correlate against — with two or more, there's no fact-based way to say which one this expectation was "supposed" to match, so the message doesn't guess. "Similar," rather than the plainer "the following calls...were made," is warranted here specifically: it's a checked fact that this one call has the right shape (same method, same argument count), not a guess.
 
-When that one call is a long string, this line becomes a diff instead of dumping both values in full — whatever's shared collapses to `…`, keeping just the part that's actually different:
+`value` is `find()`'s real parameter name, not a generic "argument 1" — reflected straight off the interface being doubled. Every argument gets its own labeled line this way, whether it matched or not, so a multi-argument call reads as one block instead of scattered fragments:
 
 ```
-Argument 1 differs:
-- '…m dolor sit baz amet, con…'
-+ '…m dolor sit Baz amet, con…'
+Double `foo` expected `save('baz', 5, true)` to be called exactly 1 time, but it was never called.
+
+The following similar call was made to `save`:
+  value: 'baz'
+  count:
+    - 5
+    + 6
+  active: true
+```
+
+`value` and `active` matched, so they're shown plainly for context; `count` didn't, so it gets a diff instead. As many arguments can differ as actually did — nothing gets collapsed away.
+
+When a differing value is a long string, its diff elides whatever's shared instead of dumping both values in full — collapsing to `…`, keeping just the part that's actually different:
+
+```
+  query:
+    - '…m dolor sit baz amet, con…'
+    + '…m dolor sit Baz amet, con…'
 ```
 
 A multi-line string (a JSON body, a rendered template, a SQL statement) diffs line by line instead, the same way a `git diff` would — only the changed line, plus a line of context on each side, survives:
 
 ```
-Argument 1 differs:
-  ...
-      "id": 1,
--     "name": "baz",
-+     "name": "Baz",
-      "active": true
-  ...
+  body:
+      ...
+          "id": 1,
+    -     "name": "baz",
+    +     "name": "Baz",
+          "active": true
+      ...
 ```
 
 ## A Call Wasn't Configured
@@ -66,6 +82,20 @@ requires every call to be configured.
 
 The following calls to `bar` were made during this test: `bar(1)`
 ```
+
+That example shows a different argument count (`bar(1)` vs. `bar(1, 2)`), so there's no argument-by-argument pairing to make — just the fact that a call happened. When the prior call has the same shape, though, it gets the same diff treatment as an unmet expectation, for the same reason: pairing this call against that one specific prior call is a fact, not a guess, once it's the only one on record:
+
+```
+Double `foo` received an unexpected call to `bar('Baz')`. Strict mode
+requires every call to be configured.
+
+The following similar call was made to `bar`:
+  value:
+    - 'baz'
+    + 'Baz'
+```
+
+This same diff also appears for a `received($method)->with(...)` assertion (see [Verification](06-verification.md)) that fails on argument mismatch — the same fact, checked against the past instead of the future.
 
 ### Method Name Suggestions
 

--- a/docs/bin/build-docs.php
+++ b/docs/bin/build-docs.php
@@ -278,7 +278,7 @@ function truncate_description(string $text, int $limit = 155): string
         $truncated = mb_substr($truncated, 0, $lastSpace);
     }
 
-    return rtrim($truncated, " ,.;:").'…';
+    return rtrim($truncated, ' ,.;:').'…';
 }
 
 /**

--- a/docs/build/failure-messages.html
+++ b/docs/build/failure-messages.html
@@ -99,28 +99,36 @@
 <div class="code-block"><div class="code-block-header"><span class="code-lang">php</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code class="language-php torchlight"><!-- Syntax highlighted by torchlight.dev --><div class='line'><span style="color: #BEC5D4;">$repository</span><span style="color: #7FDBCA;">-&gt;</span><span style="color: #82AAFF;">expects</span><span style="color: #D6DEEB;">(</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #ECC48D;">find</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #D6DEEB;">)</span><span style="color: #7FDBCA;">-&gt;</span><span style="color: #82AAFF;">with</span><span style="color: #D6DEEB;">(</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #ECC48D;">baz</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #D6DEEB;">);</span></div><div class='line'>&nbsp;</div><div class='line'><span style="color: #BEC5D4;">$repository</span><span style="color: #7FDBCA;">-&gt;</span><span style="color: #82AAFF;">find</span><span style="color: #D6DEEB;">(</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #ECC48D;">Baz</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #D6DEEB;">); </span><span style="color: #637777;">//</span><span style="color: #637777;"> note the capital B</span></div><div class='line'>&nbsp;</div><div class='line'><span style="color: #BEC5D4;">$repository</span><span style="color: #7FDBCA;">-&gt;</span><span style="color: #82AAFF;">verify</span><span style="color: #D6DEEB;">();</span></div></code></pre></div>
 <div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>Double `foo` expected `find('baz')` to be called exactly 1 time, but it was never called.
 
-The following similar call was made to `find`: `find('Baz')`
-
-Argument 1: expected 'baz', got 'Baz'
+The following similar call was made to `find`:
+  value:
+    - 'baz'
+    + 'Baz'
 </code></pre></div>
-<p>That second line comes straight from the call log: <code>find()</code> really was called, just not with anything that matched. It only appears when there's exactly one such call — with two or more, there's no fact-based way to say which one this expectation was &quot;supposed&quot; to match, so the message correlates without guessing. &quot;Similar,&quot; rather than the plainer &quot;the following calls...were made,&quot; is warranted here specifically: it's a checked fact that this one call has the right shape (same method, same argument count) and differs in exactly one place, not a guess. The third line, naming that one argument, only appears alongside that same checked fact — two or more differing arguments falls back to the plain wording instead, since there's no longer one clear thing to point at:</p>
-<div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>Double `foo` expected `save('baz', 5)` to be called exactly 1 time, but it was never called.
+<p>That block only appears when there's exactly one call to correlate against — with two or more, there's no fact-based way to say which one this expectation was &quot;supposed&quot; to match, so the message doesn't guess. &quot;Similar,&quot; rather than the plainer &quot;the following calls...were made,&quot; is warranted here specifically: it's a checked fact that this one call has the right shape (same method, same argument count), not a guess.</p>
+<p><code>value</code> is <code>find()</code>'s real parameter name, not a generic &quot;argument 1&quot; — reflected straight off the interface being doubled. Every argument gets its own labeled line this way, whether it matched or not, so a multi-argument call reads as one block instead of scattered fragments:</p>
+<div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>Double `foo` expected `save('baz', 5, true)` to be called exactly 1 time, but it was never called.
 
-The following calls to `save` were made during this test: `save('Baz', 6)`
+The following similar call was made to `save`:
+  value: 'baz'
+  count:
+    - 5
+    + 6
+  active: true
 </code></pre></div>
-<p>When that one call is a long string, this line becomes a diff instead of dumping both values in full — whatever's shared collapses to <code>…</code>, keeping just the part that's actually different:</p>
-<div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>Argument 1 differs:
-- '…m dolor sit baz amet, con…'
-+ '…m dolor sit Baz amet, con…'
+<p><code>value</code> and <code>active</code> matched, so they're shown plainly for context; <code>count</code> didn't, so it gets a diff instead. As many arguments can differ as actually did — nothing gets collapsed away.</p>
+<p>When a differing value is a long string, its diff elides whatever's shared instead of dumping both values in full — collapsing to <code>…</code>, keeping just the part that's actually different:</p>
+<div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>  query:
+    - '…m dolor sit baz amet, con…'
+    + '…m dolor sit Baz amet, con…'
 </code></pre></div>
 <p>A multi-line string (a JSON body, a rendered template, a SQL statement) diffs line by line instead, the same way a <code>git diff</code> would — only the changed line, plus a line of context on each side, survives:</p>
-<div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>Argument 1 differs:
-  ...
-      &quot;id&quot;: 1,
--     &quot;name&quot;: &quot;baz&quot;,
-+     &quot;name&quot;: &quot;Baz&quot;,
-      &quot;active&quot;: true
-  ...
+<div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>  body:
+      ...
+          &quot;id&quot;: 1,
+    -     &quot;name&quot;: &quot;baz&quot;,
+    +     &quot;name&quot;: &quot;Baz&quot;,
+          &quot;active&quot;: true
+      ...
 </code></pre></div>
 <h2 id="a-call-wasnt-configured">A Call Wasn't Configured</h2>
 <p>In <a href="/creating-doubles#strict">Strict mode</a>, a call that doesn't match a configured expectation fails the moment it happens:</p>
@@ -135,6 +143,16 @@ requires every call to be configured.
 
 The following calls to `bar` were made during this test: `bar(1)`
 </code></pre></div>
+<p>That example shows a different argument count (<code>bar(1)</code> vs. <code>bar(1, 2)</code>), so there's no argument-by-argument pairing to make — just the fact that a call happened. When the prior call has the same shape, though, it gets the same diff treatment as an unmet expectation, for the same reason: pairing this call against that one specific prior call is a fact, not a guess, once it's the only one on record:</p>
+<div class="code-block"><div class="code-block-header"><span class="code-lang">text</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code>Double `foo` received an unexpected call to `bar('Baz')`. Strict mode
+requires every call to be configured.
+
+The following similar call was made to `bar`:
+  value:
+    - 'baz'
+    + 'Baz'
+</code></pre></div>
+<p>This same diff also appears for a <code>received($method)-&gt;with(...)</code> assertion (see <a href="/verification">Verification</a>) that fails on argument mismatch — the same fact, checked against the past instead of the future.</p>
 <h3 id="method-name-suggestions">Method Name Suggestions</h3>
 <p>A typo'd method name is caught the moment you configure it:</p>
 <div class="code-block"><div class="code-block-header"><span class="code-lang">php</span><button type="button" class="copy-button" aria-label="Copy code"><svg class="copy-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><rect x="7" y="7" width="10" height="10" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M13 7V4.5A1.5 1.5 0 0 0 11.5 3h-7A1.5 1.5 0 0 0 3 4.5v7A1.5 1.5 0 0 0 4.5 13H7" stroke="currentColor" stroke-width="1.5"/></svg><svg class="check-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10.5l4 4 8-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></button></div><pre><code class="language-php torchlight"><!-- Syntax highlighted by torchlight.dev --><div class='line'><span style="color: #BEC5D4;">$repository</span><span style="color: #7FDBCA;">-&gt;</span><span style="color: #82AAFF;">expects</span><span style="color: #D6DEEB;">(</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #ECC48D;">sav</span><span style="color: #D9F5DD;">&#39;</span><span style="color: #D6DEEB;">); </span><span style="color: #637777;">//</span><span style="color: #637777;"> meant &quot;save&quot;</span></div></code></pre></div>

--- a/docs/build/llms-full.txt
+++ b/docs/build/llms-full.txt
@@ -629,37 +629,47 @@ $repository->verify();
 ```
 Double `foo` expected `find('baz')` to be called exactly 1 time, but it was never called.
 
-The following similar call was made to `find`: `find('Baz')`
-
-Argument 1: expected 'baz', got 'Baz'
+The following similar call was made to `find`:
+  value:
+    - 'baz'
+    + 'Baz'
 ```
 
-That second line comes straight from the call log: `find()` really was called, just not with anything that matched. It only appears when there's exactly one such call — with two or more, there's no fact-based way to say which one this expectation was "supposed" to match, so the message correlates without guessing. "Similar," rather than the plainer "the following calls...were made," is warranted here specifically: it's a checked fact that this one call has the right shape (same method, same argument count) and differs in exactly one place, not a guess. The third line, naming that one argument, only appears alongside that same checked fact — two or more differing arguments falls back to the plain wording instead, since there's no longer one clear thing to point at:
+That block only appears when there's exactly one call to correlate against — with two or more, there's no fact-based way to say which one this expectation was "supposed" to match, so the message doesn't guess. "Similar," rather than the plainer "the following calls...were made," is warranted here specifically: it's a checked fact that this one call has the right shape (same method, same argument count), not a guess.
+
+`value` is `find()`'s real parameter name, not a generic "argument 1" — reflected straight off the interface being doubled. Every argument gets its own labeled line this way, whether it matched or not, so a multi-argument call reads as one block instead of scattered fragments:
 
 ```
-Double `foo` expected `save('baz', 5)` to be called exactly 1 time, but it was never called.
+Double `foo` expected `save('baz', 5, true)` to be called exactly 1 time, but it was never called.
 
-The following calls to `save` were made during this test: `save('Baz', 6)`
+The following similar call was made to `save`:
+  value: 'baz'
+  count:
+    - 5
+    + 6
+  active: true
 ```
 
-When that one call is a long string, this line becomes a diff instead of dumping both values in full — whatever's shared collapses to `…`, keeping just the part that's actually different:
+`value` and `active` matched, so they're shown plainly for context; `count` didn't, so it gets a diff instead. As many arguments can differ as actually did — nothing gets collapsed away.
+
+When a differing value is a long string, its diff elides whatever's shared instead of dumping both values in full — collapsing to `…`, keeping just the part that's actually different:
 
 ```
-Argument 1 differs:
-- '…m dolor sit baz amet, con…'
-+ '…m dolor sit Baz amet, con…'
+  query:
+    - '…m dolor sit baz amet, con…'
+    + '…m dolor sit Baz amet, con…'
 ```
 
 A multi-line string (a JSON body, a rendered template, a SQL statement) diffs line by line instead, the same way a `git diff` would — only the changed line, plus a line of context on each side, survives:
 
 ```
-Argument 1 differs:
-  ...
-      "id": 1,
--     "name": "baz",
-+     "name": "Baz",
-      "active": true
-  ...
+  body:
+      ...
+          "id": 1,
+    -     "name": "baz",
+    +     "name": "Baz",
+          "active": true
+      ...
 ```
 
 ## A Call Wasn't Configured
@@ -682,6 +692,20 @@ requires every call to be configured.
 
 The following calls to `bar` were made during this test: `bar(1)`
 ```
+
+That example shows a different argument count (`bar(1)` vs. `bar(1, 2)`), so there's no argument-by-argument pairing to make — just the fact that a call happened. When the prior call has the same shape, though, it gets the same diff treatment as an unmet expectation, for the same reason: pairing this call against that one specific prior call is a fact, not a guess, once it's the only one on record:
+
+```
+Double `foo` received an unexpected call to `bar('Baz')`. Strict mode
+requires every call to be configured.
+
+The following similar call was made to `bar`:
+  value:
+    - 'baz'
+    + 'Baz'
+```
+
+This same diff also appears for a `received($method)->with(...)` assertion (see [Verification](06-verification.md)) that fails on argument mismatch — the same fact, checked against the past instead of the future.
 
 ### Method Name Suggestions
 

--- a/src/Diagnostics/ArgumentComparison.php
+++ b/src/Diagnostics/ArgumentComparison.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\Diagnostics;
+
+/**
+ * The presentation-ready, labeled counterpart to one entry from
+ * MethodExpectation::compareArguments()'s positional 'comparisons' list —
+ * built by Double::verifyState() zipping that list against
+ * DoubleState::parameterNames(), so Engine stays ignorant of reflection and
+ * Diagnostics stays ignorant of matching.
+ */
+final class ArgumentComparison
+{
+    public function __construct(
+        public readonly string $label,
+        public readonly bool $differs,
+        public readonly string $text,
+    ) {}
+}

--- a/src/Diagnostics/CallListFormatter.php
+++ b/src/Diagnostics/CallListFormatter.php
@@ -78,4 +78,43 @@ final class CallListFormatter
             self::describe($method, $callDescriptions),
         );
     }
+
+    /**
+     * renderCorrelationParagraph()'s counterpart for the one case where the
+     * observed call isn't just "a call that happened to this method" — it's
+     * a fact-checked near miss: same method, same argument count, at least
+     * one value off (see MethodExpectation::compareArguments()'s
+     * 'comparisons' kind). One line per argument — its real parameter name,
+     * then either its own value (unchanged) or a diff (changed) — instead
+     * of a single line naming the whole call.
+     *
+     * $intro is the caller's own lead-in sentence — verify()'s never-satisfied
+     * expectation (UnsatisfiedExpectationFields) and strict mode's immediate
+     * rejection (UnexpectedCallFields) are describing two different
+     * relationships (a past call that was similar vs. this call differing
+     * from what's configured), so neither words it the same way.
+     *
+     * @param  list<ArgumentComparison>  $comparisons
+     */
+    public static function renderComparisonBlock(string $intro, array $comparisons): string
+    {
+        $lines = array_map(
+            static fn (ArgumentComparison $comparison): string => $comparison->differs
+                ? sprintf("  %s:\n%s", $comparison->label, self::indent($comparison->text, '    '))
+                : sprintf('  %s: %s', $comparison->label, $comparison->text),
+            $comparisons,
+        );
+
+        // Trailing "\n" is deliberate — a new paragraph, not a continuation
+        // of the sentence before it. See DoubleException::appendFabricatedNote().
+        return sprintf("%s\n%s\n", $intro, implode("\n", $lines));
+    }
+
+    private static function indent(string $text, string $prefix): string
+    {
+        return implode("\n", array_map(
+            static fn (string $line): string => $prefix.$line,
+            explode("\n", $text),
+        ));
+    }
 }

--- a/src/Diagnostics/StringDiffer.php
+++ b/src/Diagnostics/StringDiffer.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\Diagnostics;
+
+/**
+ * A structural comparison for MethodExpectation::describeMismatch(): a
+ * plain "expected X, got Y" of two long, mostly-identical strings hides
+ * whatever actually changed in a wall of shared text. This isolates just
+ * the differing region(s) instead — line by line for a multi-line string
+ * (JSON, SQL, a rendered template), character by character for a single
+ * line — and elides everything shared around them.
+ *
+ * Both granularities run on the same underlying token comparison
+ * (diffTokens(), a standard LCS) rather than two separate algorithms —
+ * only what counts as a "token" (a line, or a character) differs. Character
+ * rather than word granularity for the single-line case is deliberate: a
+ * long token with no whitespace at all (a hash, an id, a base64 blob) has
+ * no word boundary for a word-level diff to split on, and would otherwise
+ * render as one giant unsplittable "changed" chunk.
+ *
+ * @internal
+ */
+final class StringDiffer
+{
+    /**
+     * Below this combined length, a plain "expected X, got Y" (the full
+     * values) is already easy to eyeball — a diff would save nothing and
+     * would just be one more format for a short value.
+     */
+    public const MIN_LENGTH_TO_DIFF = 40;
+
+    // Tokens of shared context kept on each side of a change before eliding
+    // the rest with "…" — enough to orient the reader without reprinting
+    // everything that didn't change.
+    private const LINE_CONTEXT = 1;
+
+    private const CHAR_CONTEXT = 12;
+
+    // diffTokens() is O(tokens(expected) * tokens(actual)); past this many
+    // tokens on either side, that stops being worth paying for and this
+    // falls back to a plain, truncated comparison instead.
+    private const MAX_TOKENS = 500;
+
+    public static function diff(string $expected, string $actual): string
+    {
+        return str_contains($expected, "\n") || str_contains($actual, "\n")
+            ? self::lineDiff($expected, $actual)
+            : self::charDiff($expected, $actual);
+    }
+
+    private static function lineDiff(string $expected, string $actual): string
+    {
+        $expectedLines = explode("\n", $expected);
+        $actualLines = explode("\n", $actual);
+
+        if (count($expectedLines) > self::MAX_TOKENS || count($actualLines) > self::MAX_TOKENS) {
+            return self::plain($expected, $actual);
+        }
+
+        $ops = self::diffTokens($expectedLines, $actualLines);
+        $rendered = [];
+
+        foreach ($ops as $index => [$type, $line]) {
+            if ($type !== '=') {
+                $rendered[] = ($type === '-' ? '- ' : '+ ').$line;
+
+                continue;
+            }
+
+            if (self::withinContext($ops, $index, self::LINE_CONTEXT)) {
+                $rendered[] = '  '.$line;
+            } elseif ($rendered === [] || end($rendered) !== '  ...') {
+                $rendered[] = '  ...';
+            }
+        }
+
+        return implode("\n", $rendered);
+    }
+
+    private static function charDiff(string $expected, string $actual): string
+    {
+        // mb_str_split, not a byte-indexed split — a common byte-level
+        // boundary could otherwise slice a multi-byte character in half.
+        $expectedChars = mb_str_split($expected);
+        $actualChars = mb_str_split($actual);
+
+        if (count($expectedChars) > self::MAX_TOKENS || count($actualChars) > self::MAX_TOKENS) {
+            return self::plain($expected, $actual);
+        }
+
+        $ops = self::diffTokens($expectedChars, $actualChars);
+
+        return sprintf(
+            "- %s\n+ %s",
+            var_export(self::renderSide($ops, '-', self::CHAR_CONTEXT), true),
+            var_export(self::renderSide($ops, '+', self::CHAR_CONTEXT), true),
+        );
+    }
+
+    /**
+     * @param  list<array{0: '='|'-'|'+', 1: string}>  $ops
+     */
+    private static function renderSide(array $ops, string $side, int $context): string
+    {
+        $out = '';
+        $elided = false;
+
+        foreach ($ops as $index => [$type, $token]) {
+            if ($type !== '=' && $type !== $side) {
+                continue; // the other side's exclusive change — not part of this rendering
+            }
+
+            if ($type === '=' && ! self::withinContext($ops, $index, $context)) {
+                if (! $elided) {
+                    $out .= '…';
+                    $elided = true;
+                }
+
+                continue;
+            }
+
+            $out .= $token;
+            $elided = false;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  list<array{0: '='|'-'|'+', 1: string}>  $ops
+     */
+    private static function withinContext(array $ops, int $index, int $radius): bool
+    {
+        $count = count($ops);
+
+        for ($k = max(0, $index - $radius); $k <= min($count - 1, $index + $radius); $k++) {
+            if ($ops[$k][0] !== '=') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The standard longest-common-subsequence edit script, used for both
+     * lineDiff() (tokens are lines) and charDiff() (tokens are characters)
+     * — the granularity differs, the algorithm doesn't.
+     *
+     * @param  list<string>  $a
+     * @param  list<string>  $b
+     * @return list<array{0: '='|'-'|'+', 1: string}>
+     */
+    private static function diffTokens(array $a, array $b): array
+    {
+        $n = count($a);
+        $m = count($b);
+        $lengths = array_fill(0, $n + 1, array_fill(0, $m + 1, 0));
+
+        for ($i = $n - 1; $i >= 0; $i--) {
+            for ($j = $m - 1; $j >= 0; $j--) {
+                $lengths[$i][$j] = $a[$i] === $b[$j]
+                    ? $lengths[$i + 1][$j + 1] + 1
+                    : max($lengths[$i + 1][$j], $lengths[$i][$j + 1]);
+            }
+        }
+
+        $ops = [];
+        $i = 0;
+        $j = 0;
+
+        while ($i < $n && $j < $m) {
+            if ($a[$i] === $b[$j]) {
+                $ops[] = ['=', $a[$i]];
+                $i++;
+                $j++;
+            } elseif ($lengths[$i + 1][$j] >= $lengths[$i][$j + 1]) {
+                $ops[] = ['-', $a[$i]];
+                $i++;
+            } else {
+                $ops[] = ['+', $b[$j]];
+                $j++;
+            }
+        }
+
+        while ($i < $n) {
+            $ops[] = ['-', $a[$i]];
+            $i++;
+        }
+
+        while ($j < $m) {
+            $ops[] = ['+', $b[$j]];
+            $j++;
+        }
+
+        return $ops;
+    }
+
+    private static function plain(string $expected, string $actual): string
+    {
+        return sprintf(
+            "- %s\n+ %s\n(too large to diff in detail)",
+            var_export(self::truncate($expected), true),
+            var_export(self::truncate($actual), true),
+        );
+    }
+
+    private static function truncate(string $value, int $limit = 200): string
+    {
+        return mb_strlen($value) > $limit ? mb_substr($value, 0, $limit).'…' : $value;
+    }
+}

--- a/src/Diagnostics/UnsatisfiedExpectation.php
+++ b/src/Diagnostics/UnsatisfiedExpectation.php
@@ -15,6 +15,17 @@ final class UnsatisfiedExpectation
      *                                        "(...)" part only — $method supplies the name).
      *                                        Pulled straight from the call log (every call to
      *                                        this method, matched or not), not a similarity guess.
+     * @param  ?string  $argumentMismatch  pre-formatted "expected N arguments, got M" — an arity
+     *                                     mismatch, the one case that can't be broken down
+     *                                     argument by argument. Set only when $otherObservedCalls
+     *                                     is exactly the one call this expectation didn't match.
+     * @param  ?list<ArgumentComparison>  $argumentComparisons  one labeled entry per constrained
+     *                                                          argument (plus any trailing Argument::remaining() ones),
+     *                                                          set only when that one observed call had the right shape
+     *                                                          (same argument count) — the one case where pairing
+     *                                                          expected against actual, argument by argument, is a
+     *                                                          fact rather than a guess. Mutually exclusive with
+     *                                                          $argumentMismatch.
      */
     public function __construct(
         public readonly string $method,
@@ -23,5 +34,7 @@ final class UnsatisfiedExpectation
         public readonly int $expectedMax,
         public readonly int $timesCalled,
         public readonly array $otherObservedCalls,
+        public readonly ?string $argumentMismatch = null,
+        public readonly ?array $argumentComparisons = null,
     ) {}
 }

--- a/src/Double.php
+++ b/src/Double.php
@@ -7,6 +7,7 @@ namespace JMac\Testing;
 use JMac\Testing\Diagnostics\ArgumentFormatter;
 use JMac\Testing\Diagnostics\DidYouMean;
 use JMac\Testing\Diagnostics\UnsatisfiedExpectation;
+use JMac\Testing\Engine\ArgumentLabeler;
 use JMac\Testing\Engine\ClassGenerator;
 use JMac\Testing\Engine\DoubleState;
 use JMac\Testing\Engine\ExceptionFactory;
@@ -199,17 +200,30 @@ final class Double
         throw ExceptionFactory::unsatisfiedExpectation(
             $state->label(),
             array_map(
-                static fn (MethodExpectation $expectation): UnsatisfiedExpectation => new UnsatisfiedExpectation(
-                    method: $expectation->method(),
-                    description: $expectation->describe(),
-                    expectedMin: $expectation->minimumCalls(),
-                    expectedMax: $expectation->maximumCalls(),
-                    timesCalled: $expectation->timesMatched(),
-                    otherObservedCalls: array_map(
-                        ArgumentFormatter::describe(...),
-                        $state->callsFor($expectation->method()),
-                    ),
-                ),
+                static function (MethodExpectation $expectation) use ($state): UnsatisfiedExpectation {
+                    $rawCalls = $state->callsFor($expectation->method());
+
+                    // Only when exactly one call was ever made to this method does
+                    // pairing "the expectation" against "the call" stop being a
+                    // guess — with two or more, there's no fact-based way to tell
+                    // which one this expectation was meant to match.
+                    $comparison = count($rawCalls) === 1
+                        ? $expectation->compareArguments($rawCalls[0])
+                        : null;
+
+                    return new UnsatisfiedExpectation(
+                        method: $expectation->method(),
+                        description: $expectation->describe(),
+                        expectedMin: $expectation->minimumCalls(),
+                        expectedMax: $expectation->maximumCalls(),
+                        timesCalled: $expectation->timesMatched(),
+                        otherObservedCalls: array_map(ArgumentFormatter::describe(...), $rawCalls),
+                        argumentMismatch: ($comparison['kind'] ?? null) === 'arity' ? $comparison['text'] : null,
+                        argumentComparisons: ($comparison['kind'] ?? null) === 'comparisons'
+                            ? ArgumentLabeler::label($state->parameterNames($expectation->method()), $comparison['comparisons'])
+                            : null,
+                    );
+                },
                 $unmet,
             ),
             $state->isFabricated(),

--- a/src/Engine/ArgumentLabeler.php
+++ b/src/Engine/ArgumentLabeler.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\Engine;
+
+use JMac\Testing\Diagnostics\ArgumentComparison;
+
+/**
+ * @internal
+ *
+ * Attaches a real parameter name to each of MethodExpectation::compareArguments()'s
+ * positional entries — Engine (MethodExpectation) stays ignorant of
+ * reflection, so this is the one place that has both a positional
+ * comparison and DoubleState::parameterNames() in hand. Shared by
+ * Double::verifyState() (a never-satisfied expectation) and
+ * ProxyBehavior::handleUnmatchedCall() (strict mode's immediate rejection)
+ * — the two places that turn a 'comparisons' result into the labeled block
+ * CallListFormatter::renderComparisonBlock() renders.
+ */
+final class ArgumentLabeler
+{
+    /**
+     * @param  list<string>  $parameterNames
+     * @param  list<array{index: int, differs: bool, text: string}>  $comparisons
+     * @return list<ArgumentComparison>
+     */
+    public static function label(array $parameterNames, array $comparisons): array
+    {
+        return array_map(
+            static fn (array $comparison): ArgumentComparison => new ArgumentComparison(
+                label: self::labelFor($parameterNames, $comparison['index']),
+                differs: $comparison['differs'],
+                text: $comparison['text'],
+            ),
+            $comparisons,
+        );
+    }
+
+    /**
+     * $parameterNames only has one name per *declared* parameter, but a
+     * variadic trailing one (or Argument::remaining()'s unconstrained tail)
+     * can cover several actual argument positions — those past the last
+     * declared name fall back to `name[n]` rather than reusing the same
+     * bare name for every one of them.
+     *
+     * @param  list<string>  $parameterNames
+     */
+    private static function labelFor(array $parameterNames, int $index): string
+    {
+        if ($parameterNames === []) {
+            return sprintf('argument %d', $index + 1);
+        }
+
+        $lastDeclaredIndex = count($parameterNames) - 1;
+
+        return $index <= $lastDeclaredIndex
+            ? $parameterNames[$index]
+            : sprintf('%s[%d]', $parameterNames[$lastDeclaredIndex], $index - $lastDeclaredIndex);
+    }
+}

--- a/src/Engine/DoubleState.php
+++ b/src/Engine/DoubleState.php
@@ -95,6 +95,34 @@ final class DoubleState
     }
 
     /**
+     * The real declared parameter names for $method, for labeling argument
+     * mismatches by name instead of position (see Double::verifyState()).
+     * A variadic parameter's name appears once here even though it can
+     * cover several actual arguments — expanding that is the caller's job,
+     * since only the caller knows the actual argument count.
+     *
+     * Empty only if $method somehow isn't reflectable, which shouldn't
+     * happen for a real registered expectation — registerExpectation()
+     * already requires declaringCandidate() to resolve before allowing
+     * expects()/allows() at all.
+     *
+     * @return list<string>
+     */
+    public function parameterNames(string $method): array
+    {
+        $declaringCandidate = $this->declaringCandidate($method);
+
+        if ($declaringCandidate === null) {
+            return [];
+        }
+
+        return array_map(
+            static fn (\ReflectionParameter $parameter): string => $parameter->getName(),
+            (new \ReflectionMethod($declaringCandidate, $method))->getParameters(),
+        );
+    }
+
+    /**
      * Every method name method_exists() would find on any target candidate,
      * for UnknownMethodException's "did you mean" suggestion.
      *

--- a/src/Engine/ExceptionFactory.php
+++ b/src/Engine/ExceptionFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMac\Testing\Engine;
 
+use JMac\Testing\Diagnostics\ArgumentComparison;
 use JMac\Testing\Diagnostics\Diagnostic;
 use JMac\Testing\Diagnostics\UnsatisfiedExpectation;
 use JMac\Testing\Exceptions\ExpectationCallLimitExceededException;
@@ -33,6 +34,7 @@ final class ExceptionFactory
 {
     /**
      * @param  list<string>  $otherObservedCalls
+     * @param  ?list<ArgumentComparison>  $argumentComparisons
      */
     public static function unexpectedCall(
         string $label,
@@ -40,12 +42,13 @@ final class ExceptionFactory
         string $argumentsDescription,
         bool $fabricated,
         array $otherObservedCalls = [],
+        ?array $argumentComparisons = null,
     ): Diagnostic&\Throwable {
         if (self::phpUnitIsAvailable()) {
-            return new PHPUnitUnexpectedCallException($label, $method, $argumentsDescription, $fabricated, $otherObservedCalls);
+            return new PHPUnitUnexpectedCallException($label, $method, $argumentsDescription, $fabricated, $otherObservedCalls, $argumentComparisons);
         }
 
-        return new UnexpectedCallException($label, $method, $argumentsDescription, $fabricated, $otherObservedCalls);
+        return new UnexpectedCallException($label, $method, $argumentsDescription, $fabricated, $otherObservedCalls, $argumentComparisons);
     }
 
     public static function expectationCallLimitExceeded(
@@ -120,6 +123,7 @@ final class ExceptionFactory
 
     /**
      * @param  list<string>  $otherObservedCalls
+     * @param  ?list<ArgumentComparison>  $argumentComparisons
      */
     public static function unsatisfiedReceivedAssertion(
         string $label,
@@ -127,12 +131,14 @@ final class ExceptionFactory
         bool $fabricated,
         string $method = '',
         array $otherObservedCalls = [],
+        ?string $argumentMismatch = null,
+        ?array $argumentComparisons = null,
     ): Diagnostic&\Throwable {
         if (self::phpUnitIsAvailable()) {
-            return new PHPUnitUnsatisfiedReceivedAssertionException($label, $description, $fabricated, $method, $otherObservedCalls);
+            return new PHPUnitUnsatisfiedReceivedAssertionException($label, $description, $fabricated, $method, $otherObservedCalls, $argumentMismatch, $argumentComparisons);
         }
 
-        return new UnsatisfiedReceivedAssertionException($label, $description, $fabricated, $method, $otherObservedCalls);
+        return new UnsatisfiedReceivedAssertionException($label, $description, $fabricated, $method, $otherObservedCalls, $argumentMismatch, $argumentComparisons);
     }
 
     /**

--- a/src/Engine/MethodExpectation.php
+++ b/src/Engine/MethodExpectation.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace JMac\Testing\Engine;
 
 use JMac\Testing\Diagnostics\Pluralizer;
+use JMac\Testing\Diagnostics\StringDiffer;
+use JMac\Testing\Diagnostics\ValueFormatter;
 use JMac\Testing\Matching\CaptureMatcher;
 use JMac\Testing\Matching\EqualsMatcher;
 use JMac\Testing\Matching\Matcher;
@@ -235,6 +237,102 @@ final class MethodExpectation
         }
 
         return true;
+    }
+
+    /**
+     * Compares $arguments position by position against this expectation's
+     * constraints, for the one case where that pairing is a plain fact
+     * rather than a guess: exactly one real call was ever observed for this
+     * method (see Double::verifyState()). Null when there's nothing to
+     * compare — with() was never called, or $arguments actually matches.
+     *
+     * Positional and unlabeled deliberately: this stays ignorant of real
+     * parameter names (a reflection concern, resolved from the target class
+     * — see DoubleState::parameterNames()) so the caller can attach labels
+     * without this needing any awareness of it.
+     *
+     * @return array{kind: 'arity', text: string}
+     *                                            | array{kind: 'comparisons', comparisons: list<array{index: int, differs: bool, text: string}>}
+     *                                            | null
+     */
+    public function compareArguments(array $arguments): ?array
+    {
+        if ($this->argumentConstraints === null) {
+            return null;
+        }
+
+        $constraints = $this->argumentConstraints;
+
+        if ($constraints !== [] && $constraints[0] instanceof NoneMatcher) {
+            return $arguments === []
+                ? null
+                : ['kind' => 'arity', 'text' => sprintf('expected no arguments, got %s', Pluralizer::pluralize(count($arguments), 'argument', 'arguments'))];
+        }
+
+        $matchesRemaining = $constraints !== [] && end($constraints) instanceof RemainingMatcher;
+
+        if ($matchesRemaining) {
+            array_pop($constraints);
+        }
+
+        $expectedCount = count($constraints);
+        $actualCount = count($arguments);
+
+        if ($matchesRemaining ? $actualCount < $expectedCount : $expectedCount !== $actualCount) {
+            return ['kind' => 'arity', 'text' => sprintf(
+                'expected %s, got %s',
+                Pluralizer::pluralize($expectedCount, 'argument', 'arguments'),
+                Pluralizer::pluralize($actualCount, 'argument', 'arguments'),
+            )];
+        }
+
+        $comparisons = [];
+        $anyDiffers = false;
+
+        foreach ($constraints as $index => $matcher) {
+            $actual = $arguments[$index];
+
+            if ($matcher->matches($actual)) {
+                $comparisons[] = ['index' => $index, 'differs' => false, 'text' => ValueFormatter::describe($actual)];
+
+                continue;
+            }
+
+            $anyDiffers = true;
+            $comparisons[] = ['index' => $index, 'differs' => true, 'text' => self::describeArgumentDiff($matcher, $actual)];
+        }
+
+        // Argument::remaining()'s trailing arguments are unconstrained by
+        // definition — always context, never a diff — but still shown, so
+        // the reader sees the whole actual call, not just its constrained
+        // prefix.
+        if ($matchesRemaining) {
+            foreach (array_slice($arguments, $expectedCount) as $offset => $actual) {
+                $comparisons[] = ['index' => $expectedCount + $offset, 'differs' => false, 'text' => ValueFormatter::describe($actual)];
+            }
+        }
+
+        return $anyDiffers ? ['kind' => 'comparisons', 'comparisons' => $comparisons] : null;
+    }
+
+    /**
+     * The "- expected\n+ actual" pair for one differing argument. Only
+     * EqualsMatcher — a bare literal passed to with() — wraps a raw value
+     * worth diffing directly when both sides are long strings; every other
+     * shape (type checks, patterns, predicates, short values) falls back to
+     * the matcher's own describe() paired against the actual value.
+     */
+    private static function describeArgumentDiff(Matcher $matcher, mixed $actual): string
+    {
+        if ($matcher instanceof EqualsMatcher) {
+            $expected = $matcher->expected();
+
+            if (is_string($expected) && is_string($actual) && strlen($expected) + strlen($actual) >= StringDiffer::MIN_LENGTH_TO_DIFF) {
+                return StringDiffer::diff($expected, $actual);
+            }
+        }
+
+        return sprintf("- %s\n+ %s", $matcher->describe(), ValueFormatter::describe($actual));
     }
 
     /**

--- a/src/Engine/ProxyBehavior.php
+++ b/src/Engine/ProxyBehavior.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMac\Testing\Engine;
 
+use JMac\Testing\Diagnostics\ArgumentComparison;
 use JMac\Testing\Diagnostics\ArgumentFormatter;
 use JMac\Testing\Double;
 
@@ -138,18 +139,57 @@ final class ProxyBehavior
     private static function handleUnmatchedCall(DoubleState $state, string $method, array $arguments, object $double): mixed
     {
         return match ($state->mode()) {
-            // callsFor($method) already includes this very call — recordCall() above ran
-            // before findMatch() — so the last entry is dropped to leave only calls that
-            // happened before this one.
-            Mode::Strict => throw ExceptionFactory::unexpectedCall(
-                $state->label(),
-                $method,
-                ArgumentFormatter::describe($arguments),
-                $state->isFabricated(),
-                array_map(ArgumentFormatter::describe(...), array_slice($state->callsFor($method), 0, -1)),
-            ),
+            Mode::Strict => throw self::unexpectedCall($state, $method, $arguments),
             Mode::Loose => SafeDefaultResolver::resolveForMethod($state, $method, $double),
             Mode::Passthru => $state->passthruTarget()->{$method}(...$arguments),
         };
+    }
+
+    private static function unexpectedCall(DoubleState $state, string $method, array $arguments): \Throwable
+    {
+        // callsFor($method) already includes this very call — recordCall() above ran
+        // before findMatch() — so the last entry is dropped to leave only calls that
+        // happened before this one.
+        $otherRawCalls = array_slice($state->callsFor($method), 0, -1);
+
+        return ExceptionFactory::unexpectedCall(
+            $state->label(),
+            $method,
+            ArgumentFormatter::describe($arguments),
+            $state->isFabricated(),
+            array_map(ArgumentFormatter::describe(...), $otherRawCalls),
+            self::comparisonsAgainstThePriorCall($state, $method, $arguments, $otherRawCalls),
+        );
+    }
+
+    /**
+     * Exactly one other call already observed for this method is the one
+     * case where pairing this failing call against it, argument by
+     * argument, is a fact rather than a guess — with two or more, there's
+     * no fact-based way to tell which one it "should" have resembled. Same
+     * criterion Double::verifyState() uses for the symmetric
+     * never-satisfied-expectation case.
+     *
+     * Reuses MethodExpectation::compareArguments() rather than a second
+     * comparison algorithm: the prior call's own arguments become literal
+     * with() constraints, so this failing call is diffed against them
+     * exactly the way it would be against a real expects()/allows().
+     *
+     * @param  list<array>  $otherRawCalls
+     * @return list<ArgumentComparison>|null
+     */
+    private static function comparisonsAgainstThePriorCall(DoubleState $state, string $method, array $arguments, array $otherRawCalls): ?array
+    {
+        if (count($otherRawCalls) !== 1) {
+            return null;
+        }
+
+        $comparison = (new MethodExpectation($method, required: false))
+            ->with(...$otherRawCalls[0])
+            ->compareArguments($arguments);
+
+        return ($comparison['kind'] ?? null) === 'comparisons'
+            ? ArgumentLabeler::label($state->parameterNames($method), $comparison['comparisons'])
+            : null;
     }
 }

--- a/src/Engine/ReceivedAssertion.php
+++ b/src/Engine/ReceivedAssertion.php
@@ -92,12 +92,27 @@ final class ReceivedAssertion
             return;
         }
 
+        // Only "too few calls matched" is an argument mismatch worth
+        // diffing. never()'s violation (exceedsMaximum() true while
+        // isSatisfied() is also true) means a call's arguments already
+        // matched fine — the problem is that it happened at all, not what
+        // its arguments were, so there's nothing to diff. And with
+        // anything but exactly one recorded call, there's no fact-based way
+        // to say which one to pair against this assertion.
+        $comparison = ! $this->expectation->isSatisfied() && count($calls) === 1
+            ? $this->expectation->compareArguments($calls[0])
+            : null;
+
         throw ExceptionFactory::unsatisfiedReceivedAssertion(
             $this->state->label(),
             $this->expectation->describe(),
             $this->state->isFabricated(),
             $this->method,
             array_map(ArgumentFormatter::describe(...), $calls),
+            argumentMismatch: ($comparison['kind'] ?? null) === 'arity' ? $comparison['text'] : null,
+            argumentComparisons: ($comparison['kind'] ?? null) === 'comparisons'
+                ? ArgumentLabeler::label($this->state->parameterNames($this->method), $comparison['comparisons'])
+                : null,
         );
     }
 }

--- a/src/Exceptions/UnexpectedCallFields.php
+++ b/src/Exceptions/UnexpectedCallFields.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMac\Testing\Exceptions;
 
+use JMac\Testing\Diagnostics\ArgumentComparison;
 use JMac\Testing\Diagnostics\CallListFormatter;
 
 /**
@@ -21,6 +22,14 @@ trait UnexpectedCallFields
      *                                            method (matched or not, same plain-fact rule
      *                                            UnsatisfiedExpectation::$otherObservedCalls
      *                                            uses), excluding this failing call itself
+     * @param  ?list<ArgumentComparison>  $argumentComparisons  one labeled entry per constrained
+     *                                                          argument, set only when $otherObservedCalls is exactly
+     *                                                          the one other call already observed for this method
+     *                                                          and it has the right shape (same argument count) as
+     *                                                          this failing one — the one case where pairing this
+     *                                                          call against that other one, argument by argument, is
+     *                                                          a fact rather than a guess. Same rule
+     *                                                          UnsatisfiedExpectation::$argumentComparisons uses.
      */
     public function __construct(
         public readonly string $label,
@@ -28,12 +37,14 @@ trait UnexpectedCallFields
         public readonly string $argumentsDescription,
         public readonly bool $fabricated = false,
         public readonly array $otherObservedCalls = [],
+        public readonly ?array $argumentComparisons = null,
     ) {
-        parent::__construct(self::renderMessage($label, $method, $argumentsDescription, $fabricated, $otherObservedCalls));
+        parent::__construct(self::renderMessage($label, $method, $argumentsDescription, $fabricated, $otherObservedCalls, $argumentComparisons));
     }
 
     /**
      * @param  list<string>  $otherObservedCalls
+     * @param  ?list<ArgumentComparison>  $argumentComparisons
      */
     public static function renderMessage(
         string $label,
@@ -41,6 +52,7 @@ trait UnexpectedCallFields
         string $argumentsDescription,
         bool $fabricated,
         array $otherObservedCalls = [],
+        ?array $argumentComparisons = null,
     ): string {
         $message = sprintf(
             'Double `%s` received an unexpected call to `%s(%s)`. Strict mode requires every call to be configured.',
@@ -49,16 +61,22 @@ trait UnexpectedCallFields
             $argumentsDescription,
         );
 
-        // A configuration suggestion only makes sense when there's nothing better to
-        // offer. It's a guess on three separate axes at once — the variable name
-        // (derived from the label, not the test's actual code), the return value
-        // (`...` is a placeholder, not real code), and the verb itself (allows() vs.
-        // expects() is a real decision this library can't make on the caller's
-        // behalf) — so once real, fact-based correlation data exists, that guess
-        // gets dropped rather than sitting next to a stronger, non-speculative fact.
-        $message .= $otherObservedCalls !== []
-            ? "\n\n".CallListFormatter::renderCorrelationParagraph($method, $otherObservedCalls)
-            : ' '.self::renderSuggestion($label, $method);
+        // A configuration suggestion, or even the plain correlation fact, only
+        // makes sense when there's nothing better to offer. Once there's
+        // exactly one other call this one is a checked near miss of,
+        // pinpointing exactly how it differs is strictly more useful than
+        // either — a guess on three axes (variable name, return value,
+        // allows() vs. expects()) or a bare list of unrelated past calls.
+        if ($argumentComparisons !== null) {
+            $message .= "\n\n".CallListFormatter::renderComparisonBlock(
+                sprintf('The following similar call was made to `%s`:', $method),
+                $argumentComparisons,
+            );
+        } elseif ($otherObservedCalls !== []) {
+            $message .= "\n\n".CallListFormatter::renderCorrelationParagraph($method, $otherObservedCalls);
+        } else {
+            $message .= ' '.self::renderSuggestion($label, $method);
+        }
 
         return DoubleException::appendFabricatedNote($message, $fabricated);
     }

--- a/src/Exceptions/UnsatisfiedExpectationFields.php
+++ b/src/Exceptions/UnsatisfiedExpectationFields.php
@@ -43,8 +43,24 @@ trait UnsatisfiedExpectationFields
     {
         $message = sprintf('Double `%s` %s.', $label, $expectation->description);
 
-        if ($expectation->otherObservedCalls !== []) {
+        if ($expectation->argumentComparisons !== null) {
+            // The one observed call had the right shape (same argument
+            // count) — labeled, argument-by-argument detail replaces the
+            // plain correlation paragraph entirely rather than sitting
+            // alongside it.
+            $message .= "\n\n".CallListFormatter::renderComparisonBlock(
+                sprintf('The following similar call was made to `%s`:', $expectation->method),
+                $expectation->argumentComparisons,
+            );
+        } elseif ($expectation->otherObservedCalls !== []) {
             $message .= "\n\n".CallListFormatter::renderCorrelationParagraph($expectation->method, $expectation->otherObservedCalls);
+
+            // Only ever set alongside the correlation paragraph above (see
+            // Double::verifyState()) — an arity mismatch, the one case that
+            // can't be broken down argument by argument.
+            if ($expectation->argumentMismatch !== null) {
+                $message .= "\n".ucfirst($expectation->argumentMismatch);
+            }
         }
 
         return DoubleException::appendFabricatedNote($message, $fabricated);

--- a/src/Exceptions/UnsatisfiedReceivedAssertionFields.php
+++ b/src/Exceptions/UnsatisfiedReceivedAssertionFields.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMac\Testing\Exceptions;
 
+use JMac\Testing\Diagnostics\ArgumentComparison;
 use JMac\Testing\Diagnostics\CallListFormatter;
 
 /**
@@ -19,6 +20,18 @@ trait UnsatisfiedReceivedAssertionFields
      *                                            or not), pulled straight from the call log —
      *                                            same plain-fact rule UnsatisfiedExpectation and
      *                                            UnexpectedCallFields use
+     * @param  ?string  $argumentMismatch  pre-formatted "expected N arguments, got M" — an arity
+     *                                     mismatch, the one case that can't be broken down
+     *                                     argument by argument. Set only when $otherObservedCalls
+     *                                     is exactly the one recorded call this assertion didn't
+     *                                     match and the failure is that too few calls matched
+     *                                     (never()'s violation — a call matching fine when it
+     *                                     shouldn't have happened at all — has no argument
+     *                                     mismatch to report).
+     * @param  ?list<ArgumentComparison>  $argumentComparisons  one labeled entry per constrained
+     *                                                          argument, set only under that same one-call, too-few-matches
+     *                                                          condition, when the shapes actually differ argument by
+     *                                                          argument rather than in count.
      */
     public function __construct(
         public readonly string $label,
@@ -26,12 +39,15 @@ trait UnsatisfiedReceivedAssertionFields
         public readonly bool $fabricated = false,
         public readonly string $method = '',
         public readonly array $otherObservedCalls = [],
+        public readonly ?string $argumentMismatch = null,
+        public readonly ?array $argumentComparisons = null,
     ) {
-        parent::__construct(self::renderMessage($label, $description, $fabricated, $method, $otherObservedCalls));
+        parent::__construct(self::renderMessage($label, $description, $fabricated, $method, $otherObservedCalls, $argumentMismatch, $argumentComparisons));
     }
 
     /**
      * @param  list<string>  $otherObservedCalls
+     * @param  ?list<ArgumentComparison>  $argumentComparisons
      */
     public static function renderMessage(
         string $label,
@@ -39,11 +55,25 @@ trait UnsatisfiedReceivedAssertionFields
         bool $fabricated,
         string $method = '',
         array $otherObservedCalls = [],
+        ?string $argumentMismatch = null,
+        ?array $argumentComparisons = null,
     ): string {
         $message = sprintf('Double `%s` %s.', $label, $description);
 
-        if ($otherObservedCalls !== []) {
+        if ($argumentComparisons !== null) {
+            $message .= "\n\n".CallListFormatter::renderComparisonBlock(
+                sprintf('The following similar call was made to `%s`:', $method),
+                $argumentComparisons,
+            );
+        } elseif ($otherObservedCalls !== []) {
             $message .= "\n\n".CallListFormatter::renderCorrelationParagraph($method, $otherObservedCalls);
+
+            // Only ever set alongside the correlation paragraph above — an
+            // arity mismatch, the one case that can't be broken down
+            // argument by argument.
+            if ($argumentMismatch !== null) {
+                $message .= "\n".ucfirst($argumentMismatch);
+            }
         }
 
         return DoubleException::appendFabricatedNote($message, $fabricated);

--- a/src/Matching/EqualsMatcher.php
+++ b/src/Matching/EqualsMatcher.php
@@ -17,6 +17,16 @@ final class EqualsMatcher implements Matcher
         private readonly mixed $expected,
     ) {}
 
+    /**
+     * @internal Used only by MethodExpectation::describeMismatch() to reach
+     * the raw value for a StringDiffer comparison — describe()/explainMismatch()
+     * only ever expose it pre-formatted.
+     */
+    public function expected(): mixed
+    {
+        return $this->expected;
+    }
+
     public function matches(mixed $actual): bool
     {
         return is_object($this->expected)

--- a/tests/Diagnostics/CallListFormatterTest.php
+++ b/tests/Diagnostics/CallListFormatterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JMac\Testing\Tests\Diagnostics;
 
+use JMac\Testing\Diagnostics\ArgumentComparison;
 use JMac\Testing\Diagnostics\CallListFormatter;
 use PHPUnit\Framework\TestCase;
 
@@ -73,6 +74,62 @@ final class CallListFormatterTest extends TestCase
         $this->assertSame(
             '`find(1)`, `save(2)`, and 2 more',
             CallListFormatter::describeCalls(['find(1)', 'save(2)', 'delete(3)', 'close(4)']),
+        );
+    }
+
+    public function test_render_comparison_block_shows_a_non_diff_entry_on_one_line(): void
+    {
+        $this->assertSame(
+            "Intro:\n  id: 42\n",
+            CallListFormatter::renderComparisonBlock('Intro:', [
+                new ArgumentComparison(label: 'id', differs: false, text: '42'),
+            ]),
+        );
+    }
+
+    /**
+     * A diff entry's -/+ pair is indented one level further than its own
+     * label — inset from it, not flush with it — so the label reads as a
+     * header for the diff nested under it rather than a sibling line.
+     */
+    public function test_render_comparison_block_insets_a_diff_entrys_lines_under_its_label(): void
+    {
+        $this->assertSame(
+            "Intro:\n  id:\n    - 42\n    + 43\n",
+            CallListFormatter::renderComparisonBlock('Intro:', [
+                new ArgumentComparison(label: 'id', differs: true, text: "- 42\n+ 43"),
+            ]),
+        );
+    }
+
+    /**
+     * Matching arguments stay plain, one-line entries for context; only the
+     * differing one gets the label-on-its-own-line diff treatment — so a
+     * multi-argument call reads as one block, not a wall of diffs.
+     */
+    public function test_render_comparison_block_mixes_context_and_diff_entries(): void
+    {
+        $this->assertSame(
+            "Intro:\n  name:\n    - 'baz'\n    + 'Baz'\n  status: 'y'\n",
+            CallListFormatter::renderComparisonBlock('Intro:', [
+                new ArgumentComparison(label: 'name', differs: true, text: "- 'baz'\n+ 'Baz'"),
+                new ArgumentComparison(label: 'status', differs: false, text: "'y'"),
+            ]),
+        );
+    }
+
+    /**
+     * A multi-line diff (StringDiffer's line-by-line output for a JSON body,
+     * say) gets every one of its own lines inset under the label, not
+     * just the first.
+     */
+    public function test_render_comparison_block_indents_every_line_of_a_multi_line_diff(): void
+    {
+        $this->assertSame(
+            "Intro:\n  body:\n      ...\n    -   line two\n    +   LINE TWO\n      ...\n",
+            CallListFormatter::renderComparisonBlock('Intro:', [
+                new ArgumentComparison(label: 'body', differs: true, text: "  ...\n-   line two\n+   LINE TWO\n  ..."),
+            ]),
         );
     }
 }

--- a/tests/Diagnostics/StringDifferTest.php
+++ b/tests/Diagnostics/StringDifferTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JMac\Testing\Tests\Diagnostics;
+
+use JMac\Testing\Diagnostics\StringDiffer;
+use PHPUnit\Framework\TestCase;
+
+final class StringDifferTest extends TestCase
+{
+    public function test_short_strings_are_shown_in_full_with_no_ellipsis(): void
+    {
+        $this->assertSame(
+            "- 'hello world'\n+ 'hello earth'",
+            StringDiffer::diff('hello world', 'hello earth'),
+        );
+    }
+
+    /**
+     * The motivating single-line case: a long shared prefix and suffix
+     * around a small differing region collapses to a windowed snippet
+     * instead of two full dumps of otherwise-identical text.
+     */
+    public function test_a_difference_surrounded_by_shared_text_is_windowed_with_ellipsis_on_both_sides(): void
+    {
+        $expected = str_repeat('a', 30).'baz'.str_repeat('a', 30);
+        $actual = str_repeat('a', 30).'BAZ'.str_repeat('a', 30);
+
+        $this->assertSame(
+            "- '…aaaaaaaaaaaabazaaaaaaaaaaaa…'\n+ '…aaaaaaaaaaaaBAZaaaaaaaaaaaa…'",
+            StringDiffer::diff($expected, $actual),
+        );
+    }
+
+    public function test_a_difference_at_the_very_start_has_no_leading_ellipsis(): void
+    {
+        $expected = 'baz'.str_repeat('a', 30);
+        $actual = 'BAZ'.str_repeat('a', 30);
+
+        $this->assertSame(
+            "- 'bazaaaaaaaaaaaa…'\n+ 'BAZaaaaaaaaaaaa…'",
+            StringDiffer::diff($expected, $actual),
+        );
+    }
+
+    public function test_a_difference_at_the_very_end_has_no_trailing_ellipsis(): void
+    {
+        $expected = str_repeat('a', 30).'baz';
+        $actual = str_repeat('a', 30).'BAZ';
+
+        $this->assertSame(
+            "- '…aaaaaaaaaaaabaz'\n+ '…aaaaaaaaaaaaBAZ'",
+            StringDiffer::diff($expected, $actual),
+        );
+    }
+
+    public function test_completely_different_strings_have_nothing_to_elide(): void
+    {
+        $this->assertSame(
+            "- 'foo'\n+ 'bar'",
+            StringDiffer::diff('foo', 'bar'),
+        );
+    }
+
+    /**
+     * Character, not word, granularity for the single-line case is
+     * deliberate: a long token with no whitespace at all (a hash, an id, a
+     * base64 blob) has no word boundary for a word-level diff to split on,
+     * and would otherwise render as one giant unsplittable "changed" chunk.
+     */
+    public function test_a_single_long_token_with_no_whitespace_still_gets_windowed(): void
+    {
+        $expected = str_repeat('a', 30).'deadbeef'.str_repeat('a', 30);
+        $actual = str_repeat('a', 30).'cafebabe'.str_repeat('a', 30);
+
+        $this->assertSame(
+            "- '…aaaaaaaaaaaadeadbeefaaaaaaaaaaaa…'\n+ '…aaaaaaaaaaaacafebabeaaaaaaaaaaaa…'",
+            StringDiffer::diff($expected, $actual),
+        );
+    }
+
+    /**
+     * Two separate differences far apart in one long line each get their
+     * own small window — the LCS comparison isolates both changed regions
+     * instead of treating everything between the first and last difference
+     * as one indivisible chunk.
+     */
+    public function test_two_separate_differences_in_one_line_are_each_windowed_independently(): void
+    {
+        $expected = 'Dear customer, your order #baz has shipped and will arrive via ground on Tuesday, thanks for your business!';
+        $actual = 'Dear customer, your order #qux has shipped and will arrive via ground on Friday, thanks for your business!';
+
+        $this->assertSame(
+            "- '…your order #baz has shipped…a ground on Tuesday, thanks …'\n+ '…your order #qux has shipped…a ground on Friday, thanks …'",
+            StringDiffer::diff($expected, $actual),
+        );
+    }
+
+    /**
+     * mb_str_split, not a byte-indexed comparison — a byte-level common
+     * boundary could otherwise slice a multi-byte character in half and
+     * corrupt it in the rendered snippet.
+     */
+    public function test_multi_byte_characters_are_never_split(): void
+    {
+        $this->assertSame(
+            "- '🙂🙂🙂A🙂🙂🙂'\n+ '🙂🙂🙂B🙂🙂🙂'",
+            StringDiffer::diff('🙂🙂🙂A🙂🙂🙂', '🙂🙂🙂B🙂🙂🙂'),
+        );
+    }
+
+    /**
+     * A multi-line string (JSON, SQL, a rendered template) diffs line by
+     * line rather than as one giant blob with a raw newline embedded in a
+     * single-quoted string — only the changed line, plus a line of
+     * context on each side, survives; the rest collapses to "...".
+     */
+    public function test_multi_line_strings_diff_line_by_line(): void
+    {
+        $expected = "{\n    \"id\": 1,\n    \"name\": \"baz\",\n    \"active\": true,\n    \"tags\": [\"a\", \"b\"]\n}";
+        $actual = "{\n    \"id\": 1,\n    \"name\": \"Baz\",\n    \"active\": true,\n    \"tags\": [\"a\", \"b\"]\n}";
+
+        $this->assertSame(
+            "  ...\n      \"id\": 1,\n-     \"name\": \"baz\",\n+     \"name\": \"Baz\",\n      \"active\": true,\n  ...",
+            StringDiffer::diff($expected, $actual),
+        );
+    }
+
+    public function test_a_multi_line_diff_marks_an_inserted_line_with_no_removed_counterpart(): void
+    {
+        $expected = "line one\nline two\nline four";
+        $actual = "line one\nline two\nline three\nline four";
+
+        $this->assertSame(
+            "  ...\n  line two\n+ line three\n  line four",
+            StringDiffer::diff($expected, $actual),
+        );
+    }
+
+    /**
+     * The O(tokens²) comparison bails out past MAX_TOKENS rather than
+     * paying for it on pathologically large input — a truncated plain
+     * comparison instead of a detailed diff.
+     */
+    public function test_extremely_long_single_line_input_falls_back_to_a_truncated_plain_comparison(): void
+    {
+        $expected = str_repeat('a', 600);
+        $actual = str_repeat('b', 600);
+
+        $result = StringDiffer::diff($expected, $actual);
+
+        $this->assertStringContainsString('(too large to diff in detail)', $result);
+        $this->assertStringContainsString('…', $result);
+    }
+}

--- a/tests/DoubleTest.php
+++ b/tests/DoubleTest.php
@@ -567,17 +567,48 @@ final class DoubleTest extends TestCase
     }
 
     /**
-     * Symmetric extension to test_verify_failure_correlates_other_calls_observed_for_the_same_method()
-     * above. Proves ProxyBehavior actually excludes the
-     * failing call itself (the one just recorded) from the correlation list,
-     * not just that the field gets populated with something.
+     * Strict mode's immediate rejection gets the same argument-by-argument
+     * diff treatment as verify()'s never-satisfied-expectation path, and the
+     * same trigger: exactly one other call already observed for this
+     * method. The prior call's own arguments become the "expected" side —
+     * not whatever's configured — so this works the same regardless of how
+     * many (or how few) expects()/allows() are registered for `find`.
      */
-    public function test_unexpected_call_correlates_other_calls_already_observed_for_the_same_method(): void
+    public function test_unexpected_call_diffs_against_the_one_other_observed_call(): void
     {
         $double = Double::for(BookRepositoryInterface::class)->strict();
         $double->allows('find')->with(123)->returns(new Book('Dune'));
 
         $double->find(123);
+
+        try {
+            $double->find(456);
+            $this->fail('Expected PHPUnitUnexpectedCallException to be thrown.');
+        } catch (PHPUnitUnexpectedCallException $exception) {
+            $message = $exception->getMessage();
+
+            $this->assertStringContainsString('received an unexpected call to `find(456)`', $message);
+            $this->assertStringContainsString("The following similar call was made to `find`:\n  id:\n    - 123\n    + 456", $message);
+        }
+    }
+
+    /**
+     * Symmetric extension to test_verify_failure_correlates_other_calls_observed_for_the_same_method()
+     * above. Two other calls already observed leaves no fact-based way to
+     * say which one this one "should" have resembled, so this falls back
+     * to plain correlation instead of a diff — and still needs to prove
+     * ProxyBehavior excludes the failing call itself (the one just
+     * recorded) from that correlation list, not just that the field gets
+     * populated with something.
+     */
+    public function test_unexpected_call_correlates_other_calls_already_observed_for_the_same_method(): void
+    {
+        $double = Double::for(BookRepositoryInterface::class)->strict();
+        $double->allows('find')->with(123)->returns(new Book('Dune'));
+        $double->allows('find')->with(789)->returns(new Book('Dune Messiah'));
+
+        $double->find(123);
+        $double->find(789);
 
         try {
             $double->find(456);
@@ -694,6 +725,53 @@ final class DoubleTest extends TestCase
         $double->received('save')->with(new Book('Dune'));
     }
 
+    /**
+     * received()'s spy-style assertion gets the same argument-by-argument
+     * diff treatment as expects()/allows()'s verify()-time path and strict
+     * mode's immediate rejection — same trigger too: exactly one other call
+     * already recorded for this method.
+     */
+    public function test_received_with_diffs_against_the_one_recorded_call(): void
+    {
+        $double = Double::for(BookRepositoryInterface::class);
+        $double->allows('find')->returns(new Book('Dune'));
+
+        $double->find(456);
+
+        try {
+            $double->received('find')->with(123)->check();
+            $this->fail('Expected PHPUnitUnsatisfiedReceivedAssertionException to be thrown.');
+        } catch (PHPUnitUnsatisfiedReceivedAssertionException $exception) {
+            $this->assertStringContainsString("The following similar call was made to `find`:\n  id:\n    - 123\n    + 456", $exception->getMessage());
+        }
+    }
+
+    /**
+     * Two or more recorded calls leaves no fact-based way to say which one
+     * this assertion was "supposed" to match, so this falls back to plain
+     * correlation instead of a diff.
+     */
+    public function test_received_with_correlates_multiple_recorded_calls_without_diffing(): void
+    {
+        $double = Double::for(BookRepositoryInterface::class);
+        $double->allows('find')->returns(new Book('Dune'));
+
+        $double->find(456);
+        $double->find(789);
+
+        try {
+            $double->received('find')->with(123)->check();
+            $this->fail('Expected PHPUnitUnsatisfiedReceivedAssertionException to be thrown.');
+        } catch (PHPUnitUnsatisfiedReceivedAssertionException $exception) {
+            $message = $exception->getMessage();
+
+            $this->assertStringContainsString('The following calls to `find` were made during this test:', $message);
+            $this->assertStringContainsString('find(456)', $message);
+            $this->assertStringContainsString('find(789)', $message);
+            $this->assertStringNotContainsString('similar call', $message);
+        }
+    }
+
     public function test_received_never_passes_when_the_method_was_not_called(): void
     {
         $double = Double::for(BookRepositoryInterface::class);
@@ -711,6 +789,30 @@ final class DoubleTest extends TestCase
         $this->expectExceptionMessageMatches('/expected `delete\(any arguments\)` to never be called, but it was called 1 time/');
 
         $double->received('delete')->never();
+    }
+
+    /**
+     * never()'s violation means a call's arguments already matched fine —
+     * the problem is that it happened at all, not what its arguments were
+     * — so there's nothing to diff even though exactly one call was
+     * recorded, unlike the too-few-matches case above.
+     */
+    public function test_received_never_violation_does_not_diff_even_with_one_recorded_call(): void
+    {
+        $double = Double::for(BookRepositoryInterface::class);
+        $double->allows('find')->returns(new Book('Dune'));
+
+        $double->find(123);
+
+        try {
+            $double->received('find')->with(123)->never()->check();
+            $this->fail('Expected PHPUnitUnsatisfiedReceivedAssertionException to be thrown.');
+        } catch (PHPUnitUnsatisfiedReceivedAssertionException $exception) {
+            $message = $exception->getMessage();
+
+            $this->assertStringContainsString('The following calls to `find` were made during this test: `find(123)`', $message);
+            $this->assertStringNotContainsString('similar call', $message);
+        }
     }
 
     public function test_received_times_requires_the_exact_count(): void
@@ -838,8 +940,79 @@ final class DoubleTest extends TestCase
             $message = $exception->getMessage();
 
             $this->assertStringContainsString('expected `find(123)` to be called exactly 1 time, but it was never called', $message);
+            $this->assertStringContainsString('The following similar call was made to `find`:', $message);
+            $this->assertStringContainsString("  id:\n    - 123\n    + 456", $message);
+        }
+    }
+
+    /**
+     * The one-observed-call case can go further than correlation: since
+     * there's exactly one real call to pair the expectation against, the
+     * message can name the real parameter and say how it differed.
+     */
+    public function test_verify_failure_names_the_mismatched_argument_by_its_real_parameter_name(): void
+    {
+        $double = Double::for(BookRepositoryInterface::class);
+        $double->expects('find')->with(123)->returns(new Book('Dune'));
+
+        $double->find(456);
+
+        try {
+            $double->verify();
+            $this->fail('Expected UnsatisfiedExpectationException to be thrown.');
+        } catch (PHPUnitUnsatisfiedExpectationException $exception) {
+            $this->assertStringContainsString("  id:\n    - 123\n    + 456", $exception->getMessage());
+        }
+    }
+
+    /**
+     * Two or more registered expectations for the same method leaves no
+     * fact-based way to say which one a given observed call was "supposed"
+     * to match — the message correlates but doesn't guess at a diff.
+     */
+    public function test_verify_failure_omits_the_argument_detail_when_more_than_one_call_was_observed(): void
+    {
+        $double = Double::for(BookRepositoryInterface::class);
+        $double->allows('find')->returns(null);
+        $double->expects('find')->with(123)->returns(new Book('Dune'));
+
+        $double->find(456);
+        $double->find(789);
+
+        try {
+            $double->verify();
+            $this->fail('Expected UnsatisfiedExpectationException to be thrown.');
+        } catch (PHPUnitUnsatisfiedExpectationException $exception) {
+            $message = $exception->getMessage();
+
             $this->assertStringContainsString('The following calls to `find` were made during this test:', $message);
-            $this->assertStringContainsString('find(456)', $message);
+            $this->assertStringNotContainsString('similar call', $message);
+            $this->assertStringNotContainsString('  id:', $message);
+        }
+    }
+
+    /**
+     * Unlike the flat, single-line summary this replaced, the labeled block
+     * format doesn't get noisy as more arguments differ — every differing
+     * argument gets named by its real parameter name, each with its own
+     * diff, alongside whichever arguments still matched.
+     */
+    public function test_verify_failure_names_every_differing_argument_when_several_differ(): void
+    {
+        $double = Double::for(VariadicInterface::class);
+        $double->expects('combine')->with('baz', 'x')->returns('stubbed');
+
+        $double->combine('Baz', 'y');
+
+        try {
+            $double->verify();
+            $this->fail('Expected UnsatisfiedExpectationException to be thrown.');
+        } catch (PHPUnitUnsatisfiedExpectationException $exception) {
+            $message = $exception->getMessage();
+
+            $this->assertStringContainsString('The following similar call was made to `combine`:', $message);
+            $this->assertStringContainsString("  glue:\n    - 'baz'\n    + 'Baz'", $message);
+            $this->assertStringContainsString("  parts:\n    - 'x'\n    + 'y'", $message);
         }
     }
 

--- a/tests/Engine/DoubleStateTest.php
+++ b/tests/Engine/DoubleStateTest.php
@@ -9,6 +9,8 @@ use JMac\Testing\Engine\MethodExpectation;
 use JMac\Testing\Engine\Mode;
 use JMac\Testing\Exceptions\ModeConfigurationException;
 use JMac\Testing\Tests\Support\BookRepositoryInterface;
+use JMac\Testing\Tests\Support\Fillable;
+use JMac\Testing\Tests\Support\VariadicInterface;
 use PHPUnit\Framework\TestCase;
 
 final class DoubleStateTest extends TestCase
@@ -108,6 +110,41 @@ final class DoubleStateTest extends TestCase
         $state = new DoubleState('Fillable&Sized', 'Fillable&Sized');
 
         $this->assertSame(['Fillable', 'Sized'], $state->targetCandidates());
+    }
+
+    public function test_parameter_names_reflects_the_real_declared_names_in_order(): void
+    {
+        $state = new DoubleState(BookRepositoryInterface::class, 'BookRepositoryInterface');
+
+        $this->assertSame(['id'], $state->parameterNames('find'));
+    }
+
+    /**
+     * A variadic parameter's own name (not one entry per actual argument —
+     * that expansion belongs to whichever caller knows the actual argument
+     * count, see Double::verifyState()).
+     */
+    public function test_parameter_names_includes_a_variadic_parameters_own_name_once(): void
+    {
+        $state = new DoubleState(VariadicInterface::class, 'VariadicInterface');
+
+        $this->assertSame(['glue', 'parts'], $state->parameterNames('combine'));
+    }
+
+    /**
+     * parameterNames() is built on declaringCandidate(), which already
+     * walks every intersection member to find the one that declares the
+     * method — this proves that resolution reaches all the way through to
+     * reflecting the real parameter names, not just locating the class.
+     * Fillable (no params) is listed first and doesn't declare `find`, so
+     * this also proves resolution doesn't stop at the first candidate.
+     */
+    public function test_parameter_names_resolves_across_an_intersection_target(): void
+    {
+        $target = Fillable::class.'&'.BookRepositoryInterface::class;
+        $state = new DoubleState($target, $target);
+
+        $this->assertSame(['id'], $state->parameterNames('find'));
     }
 
     public function test_configure_passthru_sets_the_mode_and_stores_the_real_instance(): void

--- a/tests/Engine/MethodExpectationTest.php
+++ b/tests/Engine/MethodExpectationTest.php
@@ -404,4 +404,174 @@ final class MethodExpectationTest extends TestCase
         $this->assertInstanceOf(MethodExpectation::class, $expectation);
         $this->assertTrue($expectation->isOrdered());
     }
+
+    public function test_compare_arguments_is_null_when_with_was_never_called(): void
+    {
+        $expectation = new MethodExpectation('find', required: true);
+
+        $this->assertNull($expectation->compareArguments(['whatever']));
+    }
+
+    public function test_compare_arguments_is_null_when_the_arguments_actually_match(): void
+    {
+        $expectation = (new MethodExpectation('find', required: true))->with('baz');
+
+        $this->assertNull($expectation->compareArguments(['baz']));
+    }
+
+    public function test_compare_arguments_reports_a_single_differing_argument(): void
+    {
+        $expectation = (new MethodExpectation('find', required: true))->with('baz');
+
+        $this->assertSame(
+            [
+                'kind' => 'comparisons',
+                'comparisons' => [
+                    ['index' => 0, 'differs' => true, 'text' => "- 'baz'\n+ 'Baz'"],
+                ],
+            ],
+            $expectation->compareArguments(['Baz']),
+        );
+    }
+
+    /**
+     * Every differing argument gets its own comparison entry now — unlike
+     * the single-argument-only diff this replaced, two or more differing
+     * values is no longer collapsed away, since the labeled block format
+     * this feeds doesn't get noisy the way a flat semicolon line did.
+     */
+    public function test_compare_arguments_reports_every_differing_argument(): void
+    {
+        $expectation = (new MethodExpectation('find', required: true))->with('baz', 5);
+
+        $this->assertSame(
+            [
+                'kind' => 'comparisons',
+                'comparisons' => [
+                    ['index' => 0, 'differs' => true, 'text' => "- 'baz'\n+ 'Baz'"],
+                    ['index' => 1, 'differs' => true, 'text' => "- 5\n+ 6"],
+                ],
+            ],
+            $expectation->compareArguments(['Baz', 6]),
+        );
+    }
+
+    /**
+     * A matching argument still gets a comparison entry — just a non-diff
+     * one carrying its own value — so the caller can show the whole actual
+     * call, not just whichever positions happened to differ.
+     */
+    public function test_compare_arguments_includes_matching_arguments_as_non_diff_context(): void
+    {
+        $expectation = (new MethodExpectation('find', required: true))->with('baz', 5);
+
+        $this->assertSame(
+            [
+                'kind' => 'comparisons',
+                'comparisons' => [
+                    ['index' => 0, 'differs' => false, 'text' => "'baz'"],
+                    ['index' => 1, 'differs' => true, 'text' => "- 5\n+ 6"],
+                ],
+            ],
+            $expectation->compareArguments(['baz', 6]),
+        );
+    }
+
+    public function test_compare_arguments_reports_an_argument_count_mismatch_as_a_count_not_a_position(): void
+    {
+        $expectation = (new MethodExpectation('find', required: true))->with('baz', 5);
+
+        $this->assertSame(
+            ['kind' => 'arity', 'text' => 'expected 2 arguments, got 1 argument'],
+            $expectation->compareArguments(['baz']),
+        );
+    }
+
+    public function test_compare_arguments_reports_a_none_matcher_violation_by_count(): void
+    {
+        $expectation = (new MethodExpectation('reset', required: true))->with(Argument::none());
+
+        $this->assertSame(
+            ['kind' => 'arity', 'text' => 'expected no arguments, got 1 argument'],
+            $expectation->compareArguments(['unexpected']),
+        );
+    }
+
+    public function test_compare_arguments_pairs_a_type_matchers_own_description_against_the_actual_value(): void
+    {
+        $expectation = (new MethodExpectation('save', required: true))->with(Argument::type(Book::class));
+
+        $this->assertSame(
+            [
+                'kind' => 'comparisons',
+                'comparisons' => [
+                    ['index' => 0, 'differs' => true, 'text' => '- type('.Book::class.")\n+ 'not a book'"],
+                ],
+            ],
+            $expectation->compareArguments(['not a book']),
+        );
+    }
+
+    /**
+     * The headline case: a single differing string argument long enough
+     * that dumping both values in full would bury the one-character typo —
+     * StringDiffer::MIN_LENGTH_TO_DIFF is the threshold.
+     */
+    public function test_compare_arguments_diffs_a_long_string_argument(): void
+    {
+        $expected = str_repeat('a', 30).'baz'.str_repeat('a', 30);
+        $actual = str_repeat('a', 30).'BAZ'.str_repeat('a', 30);
+
+        $expectation = (new MethodExpectation('render', required: true))->with($expected);
+
+        $this->assertSame(
+            [
+                'kind' => 'comparisons',
+                'comparisons' => [
+                    ['index' => 0, 'differs' => true, 'text' => "- '…aaaaaaaaaaaabazaaaaaaaaaaaa…'\n+ '…aaaaaaaaaaaaBAZaaaaaaaaaaaa…'"],
+                ],
+            ],
+            $expectation->compareArguments([$actual]),
+        );
+    }
+
+    public function test_compare_arguments_does_not_diff_a_non_equals_matcher_even_when_long(): void
+    {
+        $long = str_repeat('a', 60);
+        $expectation = (new MethodExpectation('find', required: true))
+            ->with(Argument::satisfies(fn (string $value): bool => $value === $long));
+
+        $this->assertSame(
+            [
+                'kind' => 'comparisons',
+                'comparisons' => [
+                    ['index' => 0, 'differs' => true, 'text' => "- satisfies(...)\n+ ".var_export('not it at all, and also quite long indeed', true)],
+                ],
+            ],
+            $expectation->compareArguments(['not it at all, and also quite long indeed']),
+        );
+    }
+
+    /**
+     * Argument::remaining()'s trailing arguments are unconstrained by
+     * definition, so they're always context (never a diff) — but they
+     * still appear, so the caller sees the whole actual call rather than
+     * just its constrained prefix.
+     */
+    public function test_compare_arguments_includes_remaining_matcher_arguments_as_context(): void
+    {
+        $expectation = (new MethodExpectation('combine', required: true))->with('-', Argument::remaining());
+
+        $this->assertSame(
+            [
+                'kind' => 'comparisons',
+                'comparisons' => [
+                    ['index' => 0, 'differs' => true, 'text' => "- '-'\n+ '+'"],
+                    ['index' => 1, 'differs' => false, 'text' => "'a'"],
+                    ['index' => 2, 'differs' => false, 'text' => "'b'"],
+                ],
+            ],
+            $expectation->compareArguments(['+', 'a', 'b']),
+        );
+    }
 }

--- a/tests/Exceptions/ExceptionMessagesTest.php
+++ b/tests/Exceptions/ExceptionMessagesTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace JMac\Testing\Tests\Exceptions;
 
+use JMac\Testing\Diagnostics\ArgumentComparison;
+use JMac\Testing\Diagnostics\StringDiffer;
 use JMac\Testing\Diagnostics\UnsatisfiedExpectation;
 use JMac\Testing\Exceptions\ExpectationCallLimitExceededException;
 use JMac\Testing\Exceptions\FabricationLimitExceededException;
@@ -42,10 +44,91 @@ final class ExceptionMessagesTest extends GoldenFileTestCase
             expectedMax: 1,
             timesCalled: 0,
             otherObservedCalls: ["'Baz'"],
+            argumentComparisons: [
+                new ArgumentComparison(label: 'value', differs: true, text: "- 'baz'\n+ 'Baz'"),
+            ],
         );
         $exception = new UnsatisfiedExpectationException('foo', [$expectation]);
 
         $this->assertMatchesGolden('unsatisfied-expectation-with-correlation', $exception->getMessage());
+    }
+
+    /**
+     * A single differing argument that's long enough to be worth eliding —
+     * StringDiffer::diff() replaces the plain "- expected\n+ actual" pair
+     * with a windowed snippet around the differing region.
+     */
+    public function test_renders_unsatisfied_expectation_with_a_long_string_argument_diff(): void
+    {
+        $expected = str_repeat('a', 30).'baz'.str_repeat('a', 30);
+        $actual = str_repeat('a', 30).'BAZ'.str_repeat('a', 30);
+
+        $expectation = new UnsatisfiedExpectation(
+            method: 'render',
+            description: sprintf('expected `render(%s)` to be called exactly 1 time, but it was never called', var_export($expected, true)),
+            expectedMin: 1,
+            expectedMax: 1,
+            timesCalled: 0,
+            otherObservedCalls: [var_export($actual, true)],
+            argumentComparisons: [
+                new ArgumentComparison(label: 'query', differs: true, text: StringDiffer::diff($expected, $actual)),
+            ],
+        );
+        $exception = new UnsatisfiedExpectationException('foo', [$expectation]);
+
+        $this->assertMatchesGolden('unsatisfied-expectation-with-long-string-diff', $exception->getMessage());
+    }
+
+    /**
+     * The headline case: a multi-line string (e.g. a JSON payload) diffs
+     * line by line rather than as one blob with a raw newline embedded in
+     * a single-quoted value.
+     */
+    public function test_renders_unsatisfied_expectation_with_a_multi_line_string_argument_diff(): void
+    {
+        $expected = "{\n    \"id\": 1,\n    \"name\": \"baz\",\n    \"active\": true\n}";
+        $actual = "{\n    \"id\": 1,\n    \"name\": \"Baz\",\n    \"active\": true\n}";
+
+        $expectation = new UnsatisfiedExpectation(
+            method: 'save',
+            description: sprintf('expected `save(%s)` to be called exactly 1 time, but it was never called', var_export($expected, true)),
+            expectedMin: 1,
+            expectedMax: 1,
+            timesCalled: 0,
+            otherObservedCalls: [var_export($actual, true)],
+            argumentComparisons: [
+                new ArgumentComparison(label: 'body', differs: true, text: StringDiffer::diff($expected, $actual)),
+            ],
+        );
+        $exception = new UnsatisfiedExpectationException('foo', [$expectation]);
+
+        $this->assertMatchesGolden('unsatisfied-expectation-with-multi-line-string-diff', $exception->getMessage());
+    }
+
+    /**
+     * Several differing arguments, alongside ones that still matched — the
+     * labeled block format doesn't collapse this away the way the flat,
+     * single-line summary it replaced had to.
+     */
+    public function test_renders_unsatisfied_expectation_with_multiple_argument_comparisons(): void
+    {
+        $expectation = new UnsatisfiedExpectation(
+            method: 'move',
+            description: "expected `move('baz', 5, 'y', 'z')` to be called exactly 1 time, but it was never called",
+            expectedMin: 1,
+            expectedMax: 1,
+            timesCalled: 0,
+            otherObservedCalls: ["'Baz', 6, 'y', 'z'"],
+            argumentComparisons: [
+                new ArgumentComparison(label: 'name', differs: true, text: "- 'baz'\n+ 'Baz'"),
+                new ArgumentComparison(label: 'id', differs: true, text: "- 5\n+ 6"),
+                new ArgumentComparison(label: 'status', differs: false, text: "'y'"),
+                new ArgumentComparison(label: 'owner', differs: false, text: "'z'"),
+            ],
+        );
+        $exception = new UnsatisfiedExpectationException('foo', [$expectation]);
+
+        $this->assertMatchesGolden('unsatisfied-expectation-with-multiple-argument-comparisons', $exception->getMessage());
     }
 
     /**
@@ -315,13 +398,21 @@ final class ExceptionMessagesTest extends GoldenFileTestCase
     }
 
     /**
-     * The symmetric extension: the same "was already observed
-     * elsewhere" fact the verify() path already shows, mirrored onto an
-     * unexpected call that matched no configured expectation.
+     * The symmetric extension: the same argument-by-argument diff the
+     * verify() path shows for its one-observed-call case, mirrored onto an
+     * unexpected call that matched no configured expectation — diffed
+     * against the one other call already observed for this method, not
+     * against whatever's configured.
      */
     public function test_renders_unexpected_call_with_correlation(): void
     {
-        $exception = new UnexpectedCallException('BookRepository', 'find', '456', otherObservedCalls: ['123']);
+        $exception = new UnexpectedCallException(
+            'BookRepository',
+            'find',
+            '456',
+            otherObservedCalls: ['123'],
+            argumentComparisons: [new ArgumentComparison(label: 'id', differs: true, text: "- 123\n+ 456")],
+        );
 
         $this->assertMatchesGolden('unexpected-call-with-correlation', $exception->getMessage());
     }
@@ -364,6 +455,32 @@ final class ExceptionMessagesTest extends GoldenFileTestCase
         $exception = new ExpectationCallLimitExceededException('SecondLink', 'delete', '1', 1, 2, fabricated: true);
 
         $this->assertMatchesGolden('call-limit-exceeded-fabricated', $exception->getMessage());
+    }
+
+    /**
+     * The argument-comparison block has to compose correctly with the
+     * fabricated-double note appended after it —
+     * DoubleException::appendFabricatedNote() rtrims trailing newlines
+     * before appending, and the block always ends in one (see
+     * CallListFormatter::renderComparisonBlock()) — so this is the one
+     * case that could plausibly mangle the boundary between them.
+     */
+    public function test_renders_unsatisfied_expectation_with_argument_comparisons_on_a_fabricated_double(): void
+    {
+        $expectation = new UnsatisfiedExpectation(
+            method: 'save',
+            description: "expected `save('baz')` to be called exactly 1 time, but it was never called",
+            expectedMin: 1,
+            expectedMax: 1,
+            timesCalled: 0,
+            otherObservedCalls: ["'Baz'"],
+            argumentComparisons: [
+                new ArgumentComparison(label: 'value', differs: true, text: "- 'baz'\n+ 'Baz'"),
+            ],
+        );
+        $exception = new UnsatisfiedExpectationException('SecondLink', [$expectation], fabricated: true);
+
+        $this->assertMatchesGolden('unsatisfied-expectation-with-argument-comparisons-fabricated', $exception->getMessage());
     }
 
     public function test_renders_fabrication_limit_exceeded(): void
@@ -454,15 +571,23 @@ final class ExceptionMessagesTest extends GoldenFileTestCase
      * The motivating scenario, mirrored from
      * test_renders_unsatisfied_expectation_with_call_correlation: a
      * received('event')->with(...) assertion fails on argument mismatch, even
-     * though the method really was called — just with something else.
+     * though the method really was called — just with something else. Diffed
+     * against that one recorded call, the same way the verify()-time and
+     * strict-mode paths are.
      */
     public function test_renders_unsatisfied_received_assertion_with_call_correlation(): void
     {
+        $expected = 'this text does not match what was actually logged';
+        $actual = 'found usages of renamed pagination methods';
+
         $exception = new UnsatisfiedReceivedAssertionException(
             'AnalyticsHelper',
-            "expected `event('this text does not match what was actually logged')` to be called at least 1 time, but it was called 0 times",
+            sprintf('expected `event(%s)` to be called at least 1 time, but it was called 0 times', var_export($expected, true)),
             method: 'event',
-            otherObservedCalls: ["'found usages of renamed pagination methods'"],
+            otherObservedCalls: [var_export($actual, true)],
+            argumentComparisons: [
+                new ArgumentComparison(label: 'message', differs: true, text: StringDiffer::diff($expected, $actual)),
+            ],
         );
 
         $this->assertMatchesGolden('unsatisfied-received-assertion-with-correlation', $exception->getMessage());

--- a/tests/fixtures/exceptions/unexpected-call-with-correlation.txt
+++ b/tests/fixtures/exceptions/unexpected-call-with-correlation.txt
@@ -1,3 +1,6 @@
 Double `BookRepository` received an unexpected call to `find(456)`. Strict mode requires every call to be configured.
 
-The following calls to `find` were made during this test: `find(123)`
+The following similar call was made to `find`:
+  id:
+    - 123
+    + 456

--- a/tests/fixtures/exceptions/unsatisfied-expectation-with-argument-comparisons-fabricated.txt
+++ b/tests/fixtures/exceptions/unsatisfied-expectation-with-argument-comparisons-fabricated.txt
@@ -1,0 +1,8 @@
+Double `SecondLink` expected `save('baz')` to be called exactly 1 time, but it was never called.
+
+The following similar call was made to `save`:
+  value:
+    - 'baz'
+    + 'Baz'
+
+Note: this double was returned automatically. You will need to configure it explicitly if you want it to behave differently.

--- a/tests/fixtures/exceptions/unsatisfied-expectation-with-correlation.txt
+++ b/tests/fixtures/exceptions/unsatisfied-expectation-with-correlation.txt
@@ -1,3 +1,6 @@
 Double `foo` expected `bar('baz')` to be called exactly 1 time, but it was never called.
 
-The following calls to `bar` were made during this test: `bar('Baz')`
+The following similar call was made to `bar`:
+  value:
+    - 'baz'
+    + 'Baz'

--- a/tests/fixtures/exceptions/unsatisfied-expectation-with-long-string-diff.txt
+++ b/tests/fixtures/exceptions/unsatisfied-expectation-with-long-string-diff.txt
@@ -1,0 +1,6 @@
+Double `foo` expected `render('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaabazaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')` to be called exactly 1 time, but it was never called.
+
+The following similar call was made to `render`:
+  query:
+    - '…aaaaaaaaaaaabazaaaaaaaaaaaa…'
+    + '…aaaaaaaaaaaaBAZaaaaaaaaaaaa…'

--- a/tests/fixtures/exceptions/unsatisfied-expectation-with-multi-line-string-diff.txt
+++ b/tests/fixtures/exceptions/unsatisfied-expectation-with-multi-line-string-diff.txt
@@ -1,0 +1,14 @@
+Double `foo` expected `save('{
+    "id": 1,
+    "name": "baz",
+    "active": true
+}')` to be called exactly 1 time, but it was never called.
+
+The following similar call was made to `save`:
+  body:
+      ...
+          "id": 1,
+    -     "name": "baz",
+    +     "name": "Baz",
+          "active": true
+      ...

--- a/tests/fixtures/exceptions/unsatisfied-expectation-with-multiple-argument-comparisons.txt
+++ b/tests/fixtures/exceptions/unsatisfied-expectation-with-multiple-argument-comparisons.txt
@@ -1,0 +1,11 @@
+Double `foo` expected `move('baz', 5, 'y', 'z')` to be called exactly 1 time, but it was never called.
+
+The following similar call was made to `move`:
+  name:
+    - 'baz'
+    + 'Baz'
+  id:
+    - 5
+    + 6
+  status: 'y'
+  owner: 'z'

--- a/tests/fixtures/exceptions/unsatisfied-received-assertion-with-correlation.txt
+++ b/tests/fixtures/exceptions/unsatisfied-received-assertion-with-correlation.txt
@@ -1,3 +1,6 @@
 Double `AnalyticsHelper` expected `event('this text does not match what was actually logged')` to be called at least 1 time, but it was called 0 times.
 
-The following calls to `event` were made during this test: `event('found usages of renamed pagination methods')`
+The following similar call was made to `event`:
+  message:
+    - 'this text does not match what was actually logged'
+    + 'found usages of renamed pagination methods'


### PR DESCRIPTION
This library already points a failed expectation at the one call that probably caused it. That comparison used to dump both calls in full — now it's diffed, the same way a PHPUnit assertion would, so the actual mismatch jumps out instead of hiding in two nearly-identical blocks of text.

**Before**
```
Double `Repo` expected `find('baz')` to be called exactly 1 time, but it was never called.

The following calls to `find` were made during this test: `find('Baz')`
```

**After (single argument)**
```
Double `Repo` expected `find('baz')` to be called exactly 1 time, but it was never called.

The following similar call was made to `find`:
  value:
    - 'baz'
    + 'Baz'
```

**After (multiple arguments — only the ones that differ get a diff, the rest stay as context)**
```
Double `Repo` expected `save('baz', 5, true)` to be called exactly 1 time, but it was never called.

The following similar call was made to `save`:
  value: 'baz'
  count:
    - 5
    + 6
  active: true
```

**After (long string — collapses to just the differing region)**
```
Double `Repo` expected `find('Lorem ipsum dolor sit baz amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt')` to be called exactly 1 time, but it was never called.

The following similar call was made to `find`:
  value:
    - '…m dolor sit baz amet, con…'
    + '…m dolor sit Baz amet, con…'
```

**After (multi-line string, e.g. a JSON body — diffs line by line instead of dumping a raw newline into a quoted string)**
```
Double `Repo` expected `saveBody('{
    "id": 1,
    "name": "baz",
    "active": true
}')` to be called exactly 1 time, but it was never called.

The following similar call was made to `saveBody`:
  body:
      ...
          "id": 1,
    -     "name": "baz",
    +     "name": "Baz",
          "active": true
      ...
```

**After (strict mode — same treatment on an immediate, unexpected-call rejection)**
```
Double `Repo` received an unexpected call to `find('Baz')`. Strict mode requires every call to be configured.

The following similar call was made to `find`:
  value:
    - 'baz'
    + 'Baz'
```

**After (a `received()` assertion)**
```
Double `Repo` expected `find(123)` to be called at least 1 time, but it was never called.

The following similar call was made to `find`:
  id:
    - 123
    + 456
```

