### PR TITLE
Support PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,11 @@ jobs:
           # neither PHPUnit 11 nor 12 declares an upper PHP-version bound
           # (11.5.56's own composer.json just says "php >=8.2"), so there's
           # no technical reason to test only one PHPUnit major per PHP
-          # version. PHPUnit 13 is the exception: every 13.x release requires
-          # php >=8.4.1, so it's paired with 8.4+ only — there's no 8.3 row
-          # for it below, since that combination isn't installable.
+          # version. PHPUnit 12 requires php >=8.3 and PHPUnit 13 requires
+          # php >=8.4.1, so 8.2 is paired with PHPUnit 11 only.
+          - php: '8.2'
+            phpunit: '^11.0'
+            allow-failure: false
           - php: '8.3'
             phpunit: '^11.0'
             allow-failure: false

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^8.3"
+        "php": "^8.2"
     },
     "require-dev": {
         "laravel/pint": "^1.29",


### PR DESCRIPTION
## What

Lower the `php` requirement from `^8.3` to `^8.2` and add an 8.2 / PHPUnit 11 job to the CI matrix.

## Why

The code uses nothing newer than PHP 8.2 APIs (`ReflectionClass::isReadOnly()` landed in 8.2), so `^8.3` is stricter than the implementation needs. PHPUnit 12 requires `php >= 8.3` and PHPUnit 13 requires `>= 8.4.1`, so 8.2 can only pair with PHPUnit 11 — which the new matrix row does.

This unblocks using Double on projects that still support PHP 8.2. Concretely, it is a blocker for the [Testo](https://github.com/php-testo/testo) bridge (`testo/bridge-double`): Testo's CI matrix includes 8.2, so the current `^8.3` constraint breaks `composer install` on that leg. Context: php-testo/testo#296.

## Testing

- [x] CI matrix now exercises PHP 8.2 with PHPUnit 11 alongside the existing 8.3–8.5 rows.
